### PR TITLE
🐛 FIX: update-notifier deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"enquirer": "^2.3.4",
 		"meow": "^6.1.0",
 		"ora": "^4.0.3",
-		"puppeteer": "^2.1.1"
+		"puppeteer": "^2.1.1",
+		"update-notifier": "^4.1.0"
 	}
 }


### PR DESCRIPTION
This fixes `Error: Cannot find module 'update-notifier'` issue after global installation